### PR TITLE
Fix: add async handling to handle_token to avoid unhandled promise rejections

### DIFF
--- a/forthic-ts/src/forthic/interpreter.ts
+++ b/forthic-ts/src/forthic/interpreter.ts
@@ -549,23 +549,23 @@ export class Interpreter {
   // Handle tokens
 
   async handle_token(token: Token) {
-    if (token.type == TokenType.STRING) this.handle_string_token(token);
+    if (token.type == TokenType.STRING) await this.handle_string_token(token);
     else if (token.type == TokenType.COMMENT) this.handle_comment_token(token);
     else if (token.type == TokenType.START_ARRAY)
-      this.handle_start_array_token(token);
+      await this.handle_start_array_token(token);
     else if (token.type == TokenType.END_ARRAY)
-      this.handle_end_array_token(token);
+      await this.handle_end_array_token(token);
     else if (token.type == TokenType.START_MODULE)
       await this.handle_start_module_token(token);
     else if (token.type == TokenType.END_MODULE)
-      this.handle_end_module_token(token);
+      await this.handle_end_module_token(token);
     else if (token.type == TokenType.START_DEF)
       this.handle_start_definition_token(token);
     else if (token.type == TokenType.START_MEMO)
       this.handle_start_memo_token(token);
     else if (token.type == TokenType.END_DEF)
       this.handle_end_definition_token(token);
-    else if (token.type == TokenType.DOT_SYMBOL) this.handle_dot_symbol_token(token);
+    else if (token.type == TokenType.DOT_SYMBOL) await this.handle_dot_symbol_token(token);
     else if (token.type == TokenType.WORD) await this.handle_word_token(token);
     else if (token.type == TokenType.EOS) {
       return;
@@ -578,14 +578,14 @@ export class Interpreter {
     }
   }
 
-  handle_string_token(token: Token) {
+  async handle_string_token(token: Token) {
     const value = new PositionedString(token.string, token.location);
-    this.handle_word(new PushValueWord("<string>", value));
+    await this.handle_word(new PushValueWord("<string>", value));
   }
 
-  handle_dot_symbol_token(token: Token) {
+  async handle_dot_symbol_token(token: Token) {
     const value = new PositionedString(token.string, token.location);
-    this.handle_word(new PushValueWord("<dot-symbol>", value));
+    await this.handle_word(new PushValueWord("<dot-symbol>", value));
   }
 
   // Start/end module tokens are treated as IMMEDIATE words *and* are also compiled
@@ -607,12 +607,12 @@ export class Interpreter {
     await word.execute(self);
   }
 
-  handle_start_array_token(token: Token) {
-    this.handle_word(new PushValueWord("<start_array_token>", token));
+  async handle_start_array_token(token: Token) {
+    await this.handle_word(new PushValueWord("<start_array_token>", token));
   }
 
-  handle_end_array_token(_token: Token) {
-    this.handle_word(new EndArrayWord());
+  async handle_end_array_token(_token: Token) {
+    await this.handle_word(new EndArrayWord());
   }
 
   handle_comment_token(_token: Token) {


### PR DESCRIPTION
Running a minimal Forthic program like `]` resulted in a unhandled promise exception:

```
./src/forthicModules/utils/example-test/ModuleMock.test.ts (uncaught error)
error: (in promise) StackUnderflowError: Stack underflow
    at Interpreter.stack_pop (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:322:19)
    at EndArrayWord.execute (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:46:27)
    at Interpreter.handle_word (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:544:24)
    at Interpreter.handle_end_array_token (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:494:14)
    at Interpreter.handle_token (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:443:18)
    at Interpreter.run_with_tokenizer (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:278:24)
    at Interpreter.run (file:///Users/liam/bigbasinlabs/at-mention/api/node_modules/.deno/@forthic+interp@0.19.1/node_modules/@forthic/interp/dist/cjs/forthic/interpreter.js:248:24)
    at run_forthic (file:///Users/liam/bigbasinlabs/at-mention/api/src/forthicModules/utils/example-test/ModuleMock.test.ts:54:16)
    at file:///Users/liam/bigbasinlabs/at-mention/api/src/forthicModules/utils/example-test/ModuleMock.test.ts:146:17
    at assertRejects (https://jsr.io/@std/assert/1.0.14/rejects.ts:86:29)
This error was not caught from a test and caused the test runner to fail on the referenced module.
It most likely originated from a dangling promise, event/timeout handler or top-level code.
```

Looks like the handle token family was the root cause - some of them were calling `handle_word`, which is `async`, but not awaiting the promises. `handle_word`, in turn, would call the async `execute_word`. Tokens like `]` perform a stack pop while executing and therefore can throw StackUnderflow errors.

I went through all the tokens and fixed all the missing awaits related to `handle_word` that I could find and verified in my project that the promise now rejects as expected.